### PR TITLE
fixes

### DIFF
--- a/kuma/redirects/redirects.py
+++ b/kuma/redirects/redirects.py
@@ -1177,32 +1177,32 @@ firefox_source_docs_redirectpatterns = [
     external_redirect(pattern, firefox_source_docs_root_url + path)
     for (pattern, path) in [
         (
-            r"(?:docs/)?/Mozilla/Memory_Sanitizer(?:/|$)",
+            r"(?:docs/)?Mozilla/Memory_Sanitizer(?:/|$)",
             "/tools/sanitizer/memory_sanitizer.html#memory-sanitizer",
         ),
         (
-            r"(?:docs/)?/Debugging_Mozilla_with_gdb(?:/|$)",
-            "/contributing/debugging/debugging_mozilla_with_gdb.html",
+            r"(?:docs/)?Debugging_Mozilla_with_gdb(?:/|$)",
+            "/contributing/debugging/debugging_firefox_with_gdb.html",
         ),
         (
-            r"(?:docs/)?/Debugging_Mozilla_with_lldb(?:/|$)",
-            "/contributing/debugging/debugging_mozilla_with_lldb.html",
+            r"(?:docs/)?Debugging_Mozilla_with_lldb(?:/|$)",
+            "/contributing/debugging/debugging_firefox_with_lldb.html",
         ),
         (
-            r"(?:docs/)?/Understanding_crash_reports(?:/|$)",
+            r"(?:docs/)?Understanding_crash_reports(?:/|$)",
             "/contributing/debugging/understanding_crash_reports.html",
         ),
         (
-            r"(?:docs/)?/Debugging_a_minidump(?:/|$)",
+            r"(?:docs/)?Debugging_a_minidump(?:/|$)",
             "/contributing/debugging/debugging_a_minidump.html",
         ),
         (
-            r"(?:docs/)?/Debugging_Mozilla_with_Valgrind(?:/|$)",
-            "/contributing/debugging/debugging_mozilla_with_valgrind.html",
+            r"(?:docs/)?Debugging_Mozilla_with_Valgrind(?:/|$)",
+            "/contributing/debugging/debugging_firefox_with_valgrind.html",
         ),
         (
-            r"(?:docs/)?/Debugging/Record_and_Replay_Debugging_Firefox(?:/|$)",
-            "/contributing/debugging/record_and_replay_debugging_firefox.html",
+            r"(?:docs/)?Debugging/Record_and_Replay_Debugging_Firefox(?:/|$)",
+            "/contributing/debugging/debugging_firefox_with_rr.html",
         ),
     ]
 ]

--- a/tests/headless/map_301.py
+++ b/tests/headless/map_301.py
@@ -974,11 +974,11 @@ FIREFOX_SOURCE_DOCS_URLS = list(
             ),
             url_test(
                 "{/en-US,/pl,}/{docs/,}Debugging_Mozilla_with_gdb",
-                "https://firefox-source-docs.mozilla.org/contributing/debugging/debugging_mozilla_with_gdb.html",
+                "https://firefox-source-docs.mozilla.org/contributing/debugging/debugging_firefox_with_gdb.html",
             ),
             url_test(
                 "{/en-US,/pl,}/{docs/,}Debugging_Mozilla_with_lldb",
-                "https://firefox-source-docs.mozilla.org/contributing/debugging/debugging_mozilla_with_lldb.html",
+                "https://firefox-source-docs.mozilla.org/contributing/debugging/debugging_firefox_with_lldb.html",
             ),
             url_test(
                 "{/en-US,/pl,}/{docs/,}Understanding_crash_reports",
@@ -990,11 +990,11 @@ FIREFOX_SOURCE_DOCS_URLS = list(
             ),
             url_test(
                 "{/en-US,/pl,}/{docs/,}Debugging_Mozilla_with_Valgrind",
-                "https://firefox-source-docs.mozilla.org/contributing/debugging/debugging_mozilla_with_valgrind.html",
+                "https://firefox-source-docs.mozilla.org/contributing/debugging/debugging_firefox_with_valgrind.html",
             ),
             url_test(
                 "{/en-US,/pl,}/{docs/,}Debugging/Record_and_Replay_Debugging_Firefox",
-                "https://firefox-source-docs.mozilla.org/contributing/debugging/record_and_replay_debugging_firefox.html",
+                "https://firefox-source-docs.mozilla.org/contributing/debugging/debugging_firefox_with_rr.html",
             ),
         )
     )


### PR DESCRIPTION
@fiji-flo I had to test my thoughts anyway, so I thought I'd submit them as a PR to your PR. Two things:

- the extra `/` in the redirect patterns, so for example `(?:docs/)?/Mozilla` should be `(?:docs/)?Mozilla`
- I noticed that some of the final destination URL's had changed (see https://github.com/mdn/kuma/issues/7412#issuecomment-702385107)